### PR TITLE
Fix signedness warnings in tests

### DIFF
--- a/test/absolute_test.c
+++ b/test/absolute_test.c
@@ -12,7 +12,7 @@ int absolute_check()
     "./simple", ".././simple"};
   const char *absolute_paths[] = {"/", "/test", "/../test/", "/../another_test",
     "/./simple", "/.././simple"};
-  int i;
+  size_t i;
 
   cwk_path_set_style(CWK_STYLE_UNIX);
 

--- a/test/relative_test.c
+++ b/test/relative_test.c
@@ -11,7 +11,7 @@ int relative_check()
     "./simple", ".././simple"};
   const char *absolute_paths[] = {"/", "/test", "/../test/", "/../another_test",
     "/./simple", "/.././simple"};
-  int i;
+  size_t i;
 
   cwk_path_set_style(CWK_STYLE_UNIX);
 


### PR DESCRIPTION
Following  warnings prevent me from compiling lib with `-Werror`:

```
relative_test.c: In function ‘relative_check’:
relative_test.c:18:17: error: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Werror=sign-compare]
   18 |   for (i = 0; i < ARRAY_SIZE(relative_paths); ++i) {
      |                 ^
relative_test.c:24:17: error: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Werror=sign-compare]
   24 |   for (i = 0; i < ARRAY_SIZE(absolute_paths); ++i) {

```
