### PR TITLE
Add meson.build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,13 @@
+# Project
+project('cwalk', 'c')
+
+# Library
+cwalk = shared_library(	'cwalk', 'src/cwalk.c',
+						install: true,
+						include_directories: 'include',
+						soversion: 1, version: '1.0.0'
+)
+
+install_headers('include/cwalk.h')
+
+cwalk_dep = declare_dependency(include_directories: 'include', link_with: cwalk)


### PR DESCRIPTION
This meson.build file, make it possible for those who are using meson build system to integrate easily this project into the subproject folder.