### PR TITLE
Add cwk_path_get_executable_path

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,4 +26,4 @@ build:
   verbosity: minimal
 
 test_script:
-  - cmd: c:\projects\cwalk\build.win\Release\cwalktest.exe
+  - cmd: ctest -C Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
  - make test
 
  # Run tests for get_executable_path
- - bash ../test/test_executable_paths.sh cwalktest_exe_path
+ - bash ../test/test_executable_paths.sh ./cwalktest_exe_path
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,8 @@ script:
  - make
  - make test
 
+ # Run tests for get_executable_path
+ - bash ../test/test_executable_paths.sh cwalktest_exe_path
+
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,5 @@ script:
  - make
  - make test
 
- # Run tests for get_executable_path
- - bash ../test/test_executable_paths.sh ./cwalktest_exe_path
-
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,12 +254,15 @@ if(ENABLE_TESTS)
   enable_warnings(cwalktest)
     
   target_link_libraries(cwalktest PRIVATE cwalk)
-endif()
 
-add_executable(cwalktest_exe_path
-        "${TEST_DIRECTORY}/executable_path_test.c")
-enable_warnings(cwalktest_exe_path)
-target_link_libraries(cwalktest_exe_path PRIVATE cwalk)
+  add_executable(cwalktest_exe_path "${TEST_DIRECTORY}/executable_path_test.c")
+  enable_warnings(cwalktest_exe_path)
+  target_link_libraries(cwalktest_exe_path PRIVATE cwalk)
+
+  create_shellscript_test(executable_path
+          "${TEST_DIRECTORY}/test_executable_paths.sh"
+          "${CMAKE_CURRENT_BINARY_DIR}/cwalktest_exe_path")
+endif()
 
 write_basic_package_version_file("CwalkConfigVersion.cmake"
   VERSION ${cwalk_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,11 @@ if(ENABLE_TESTS)
   target_link_libraries(cwalktest PRIVATE cwalk)
 endif()
 
+add_executable(cwalktest_exe_path
+        "${TEST_DIRECTORY}/executable_path_test.c")
+enable_warnings(cwalktest_exe_path)
+target_link_libraries(cwalktest_exe_path PRIVATE cwalk)
+
 write_basic_package_version_file("CwalkConfigVersion.cmake"
   VERSION ${cwalk_VERSION}
   COMPATIBILITY SameMajorVersion)

--- a/cmake/CreateTestList.cmake
+++ b/cmake/CreateTestList.cmake
@@ -13,3 +13,17 @@ function(create_test list_name unit_name test_name)
   set(TEST_LIST_CONTENT_${list_name} "${TEST_LIST_CONTENT_${list_name}}  XX(${unit_name},${test_name}) \\\n" PARENT_SCOPE)
   add_test(NAME "${unit_name}_${test_name}" COMMAND ${TEST_LIST_TARGET_${list_name}} ${unit_name} ${test_name})
 endfunction()
+
+function(create_shellscript_test unit_name script_path script_arg)
+  if (WIN32)
+    find_program(SHELL_CMD bash.exe REQUIRED
+            PATHS "C:\\Program Files\\Git\\bin" "C:\\Program Files (x86)\\Git\\bin")
+  else()
+    set(SHELL_CMD "/bin/sh")
+  endif()
+
+  add_test(
+          NAME "shellscript_${unit_name}"
+          COMMAND "${SHELL_CMD}" "${script_path}" ${script_arg}
+          COMMAND_EXPAND_LISTS)
+endfunction()

--- a/include/cwalk.h
+++ b/include/cwalk.h
@@ -495,7 +495,9 @@ CWK_PUBLIC enum cwk_path_style cwk_path_get_style(void);
     defined(__sun)
 /**
  * @brief Gets the path to the executable calling this function, with all
- * aliases and symlinks resolved.
+ * aliases and symlinks resolved. The path returned in the buffer is not
+ * necessarily normalized; use cwk_path_normalize to normalize the result.
+ * The buffer will always be null-terminated.
  *
  * Since this function relies on OS-dependent APIs, it is only available on the
  * following platforms: Windows, MacOS, Linux, FreeBSD, NetBSD, DragonFlyBSD,
@@ -506,7 +508,7 @@ CWK_PUBLIC enum cwk_path_style cwk_path_get_style(void);
  * @param buffer_size The size of the buffer.
  * @param is_truncated If the buffer is too small to hold the entire path, the
  * value that this pointer points to will be set to true. If this pointer is
- * null, no change will occur.
+ * null, no change will occur.`
  * @return The length of the string written to the buffer.
  */
 CWK_PUBLIC size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,

--- a/include/cwalk.h
+++ b/include/cwalk.h
@@ -490,6 +490,29 @@ CWK_PUBLIC void cwk_path_set_style(enum cwk_path_style style);
  */
 CWK_PUBLIC enum cwk_path_style cwk_path_get_style(void);
 
+#if defined(_WIN32)      || defined(__APPLE__)  || defined(__linux__)     || \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
+    defined(__sun)
+/**
+ * @brief Gets the path to the executable calling this function, with all
+ * aliases and symlinks resolved.
+ *
+ * Since this function relies on OS-dependent APIs, it is only available on the
+ * following platforms: Windows, MacOS, Linux, FreeBSD, NetBSD, DragonFlyBSD,
+ * and Solaris.
+ *
+ * @param buffer The buffer where the path to the executable will be written.
+ * On return, the string will be null-terminated.
+ * @param buffer_size The size of the buffer.
+ * @param is_truncated If the buffer is too small to hold the entire path, the
+ * value that this pointer points to will be set to true. If this pointer is
+ * null, no change will occur.
+ * @return The length of the string written to the buffer.
+ */
+CWK_PUBLIC size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
+                                               bool * is_truncated);
+#endif
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/cwalk.c
+++ b/src/cwalk.c
@@ -1476,7 +1476,7 @@ size_t resolve_symbolic_link(const char *to_resolve, char * buffer,
   }
 
   // readlink will never write more than buffer_size bytes
-  assert(bytes_written < buffer_size);
+  assert(bytes_written <= buffer_size);
 
   // Is there enough space in the buffer to add a null terminal?
   if (bytes_written == buffer_size) {

--- a/src/cwalk.c
+++ b/src/cwalk.c
@@ -5,14 +5,15 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(__linux__)  || defined(__DragonFly__) || \
-    defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__linux__)  || defined(__DragonFly__) || defined(__NetBSD__)
 #include <unistd.h>             // readlink
 #elif defined(_WIN32)
 #include <windows.h>            // GetModuleFileNameA
 #elif defined(__APPLE__)
+#include <stdlib.h>             // malloc/free
 #include <stdint.h>             // uint32_t
 #include <mach-o/dyld.h>        // _NSGetExecutablePath
+#include <unistd.h>             // readlink
 #elif defined(__FreeBSD__)
 #include <sys/sysctl.h>         // sysctl
 #elif defined(__sun)

--- a/src/cwalk.c
+++ b/src/cwalk.c
@@ -1525,7 +1525,7 @@ size_t resolve_if_symlink(char * buffer, size_t buffer_size,
 
   // If the buffer's too short, return failure
   if ((size_t)sb.st_size + 1 > buffer_size) {
-    *is_truncated = true;
+    if (is_truncated) { *is_truncated = true; }
     buffer[0] = '\0';
     return 0;
   }

--- a/src/cwalk.c
+++ b/src/cwalk.c
@@ -1508,7 +1508,7 @@ size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
   // the last error to ERROR_INSUFFICIENT_BUFFER.
   // On failure for any other reason, it returns 0.
 
-  bytes_written = GetModuleFileNameA(nullptr, lp_buffer, buffer_size);
+  bytes_written = GetModuleFileNameA(NULL, lp_buffer, (DWORD)buffer_size);
 
   // Did an error occur?
   if (!bytes_written) {

--- a/src/cwalk.c
+++ b/src/cwalk.c
@@ -5,6 +5,20 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(__linux__)  || defined(__DragonFly__) || \
+    defined(__NetBSD__) || defined(__APPLE__)
+#include <unistd.h>             // readlink
+#elif defined(_WIN32)
+#include <windows.h>            // GetModuleFileNameA
+#elif defined(__APPLE__)
+#include <stdint.h>             // uint32_t
+#include <mach-o/dyld.h>	// _NSGetExecutablePath
+#elif defined(__FreeBSD__)
+#include <sys/sysctl.h>         // sysctl
+#elif defined(__sun)
+#include <stdlib.h>             // getexecname
+#endif
+
 /**
  * We try to default to a different path style depending on the operating
  * system. So this should detect whether we should use windows or unix paths.
@@ -1434,3 +1448,165 @@ enum cwk_path_style cwk_path_get_style(void)
   // Simply return the path style which we store in a global variable.
   return path_style;
 }
+
+#if defined(_WIN32)
+size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
+                                    bool * is_truncated)
+{
+  LPSTR lp_buffer;        // same as char *
+  DWORD bytes_written;    // same as uint32_t
+
+  lp_buffer = buffer;
+
+  // From docs at https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea
+  // GetModuleFileNameA:
+  // If the function succeeds, the return value is the length of the string
+  // that is copied to the buffer, in characters, not including the terminating
+  // null character. If the buffer is too small to hold the module name, the
+  // string is truncated to buffer_size characters including the terminating
+  // null character, the function returns buffer_size, and the function sets
+  // the last error to ERROR_INSUFFICIENT_BUFFER.
+  // On failure for any other reason, it returns 0.
+
+  bytes_written = GetModuleFileNameA(nullptr, lp_buffer, buffer_size);
+
+  // Did an error occur?
+  if (!bytes_written) {
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  // Was the string truncated?
+  if (bytes_written == buffer_size) {
+    if (is_truncated) { *is_truncated = true; }
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  // Otherwise, we need to add null-terminal and return.
+  buffer[bytes_written] = '\0';
+  return bytes_written;
+}
+#elif defined(__APPLE__)
+size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
+                                    bool * is_truncated)
+{
+  uint32_t len;
+  len = buffer_size;
+
+  // From docs at https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dyld.3.html
+  // _NSGetExecutablePath() copies the path of the main executable into the
+  // buffer.  The buffer_size parameter should initially be the size of the
+  // buffer.  This function returns 0 if the path was successfully copied.
+  // It returns -1 if the buffer is not large enough, and * buffer_size is set
+  // to the size required.  Note that _NSGetExecutablePath() will return
+  // "a path" to the executable not a "real path" to the executable.  That is,
+  // the path may be a symbolic link and not the real file. With deep
+  // directories the total bufsize needed could be more than MAXPATHLEN.
+  if (_NSGetExecutablePath(buffer, &len) != 0) {
+    if (is_truncated) { *is_truncated = true; }
+    buffer[0] = '\0';
+    return 0;
+  }
+  // TODO: call readlink to resolve symbolic links; should just reuse linux code
+  return len;
+}
+#elif defined(__linux__) || defined(__NetBSD__) || defined(__DragonFly__)
+
+// We will use readlink to determine executable path
+#if defined(__linux__)
+#define CWK_READLINK_PATH "/proc/self/exe"
+#elif defined(__NetBSD__)
+#define CWK_READLINK_PATH "/proc/curproc/exe"
+#elif defined(__DragonFly__)
+#define CWK_READLINK_PATH "/proc/curproc/file"
+#endif
+
+size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
+                                    bool * is_truncated)
+{
+  size_t bytes_written;
+
+  // From readlink manpage at https://linux.die.net/man/3/readlink:
+  // readlink() places the contents of the symbolic link pathname in the buffer
+  // buffer, which has size buffer_size. readlink() does not append a
+  // terminating null byte to buffer. It will (silently) truncate the contents
+  // (to a length of buffer_size characters), in case the buffer is too small
+  // to hold all of the contents.
+
+  // On success, readlink returns the number of bytes placed in buffer. If the
+  // returned value equals buffer_size, then truncation may have occurred.
+  // On error, -1 is returned and errno is set to indicate the error.
+  bytes_written = (size_t) readlink(CWK_READLINK_PATH, buffer, buffer_size);
+
+  // If bytes_written is negative, the call failed and errno contains the error
+  if ((ssize_t)bytes_written < 0) {
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  // readlink will never write more than buffer_size bytes
+  assert(bytes_written < buffer_size);
+
+  // Is there enough space in the buffer to add a null terminal?
+  if (bytes_written == buffer_size) {
+    if (is_truncated) { *is_truncated = true; }
+    buffer[0] = '\0';
+    return 0;
+  }
+  // Otherwise, add the null-terminal and return.
+  buffer[bytes_written] = '\0';
+  return bytes_written;
+}
+#elif defined(__FreeBSD__)
+size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
+                                    bool * is_truncated)
+{
+  // sysctl(3) docs at https://www.unix.com/man-page/FreeBSD/3/sysctl/
+
+  int mib[4];   // management information base
+
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PATHNAME;
+  mib[3] = -1;
+
+  // this would put the required size in buffer_size
+  //sysctl(mib, 4, NULL, &buffer_size, NULL, 0);
+
+  // sysctl returns -1 on error, or 0 on success
+  if (sysctl(mib, 4, buffer, &buffer_size, NULL, 0) != 0) {
+    // If the buffer was too small, sysctl would set errno to ENOMEM
+    if (errno == ENOMEM && is_truncated) { *is_truncated = true; }
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  return strlen(buffer);
+}
+
+#elif defined(__sun)  // Solaris
+size_t cwk_path_get_executable_path(char * buffer, size_t buffer_size,
+                                    bool * is_truncated)
+{
+  // getexecname(3) docs at https://docs.oracle.com/cd/E19253-01/816-5168/6mbb3hrb1/index.html
+
+  const char * name;
+  size_t name_len;
+
+  name = getexecname();
+  if (!name) {
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  name_len = strlen(name);
+  if (buffer_size <= name_len) {
+    if (is_truncated) { *is_truncated = true; }
+    buffer[0] = '\0';
+    return 0;
+  }
+  strcpy(buffer, name);
+  return name_len;
+}
+#endif

--- a/test/executable_path_test.c
+++ b/test/executable_path_test.c
@@ -6,6 +6,14 @@
 #define adequate_buffer_len 4096
 #define inadequate_buffer_len 2
 
+int compare_normalized_paths(const char *a, const char *b)
+{
+  char normal_a[adequate_buffer_len], normal_b[adequate_buffer_len];
+  cwk_path_normalize(a, normal_a, sizeof(normal_a));
+  cwk_path_normalize(b, normal_b, sizeof(normal_b));
+  return strcmp(normal_a, normal_b);
+}
+
 int executable_path_adequate_buffer(const char * expected_exe_path)
 {
   char buffer[adequate_buffer_len];
@@ -13,7 +21,7 @@ int executable_path_adequate_buffer(const char * expected_exe_path)
   if (cwk_path_get_executable_path(buffer, adequate_buffer_len, &is_trunc) == 0) {
     return EXIT_FAILURE;
   }
-  if (strcmp(buffer, expected_exe_path) != 0) {
+  if (compare_normalized_paths(buffer, expected_exe_path) != 0) {
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/test/executable_path_test.c
+++ b/test/executable_path_test.c
@@ -1,0 +1,82 @@
+#include <cwalk.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define adequate_buffer_len 4096
+#define inadequate_buffer_len 2
+
+int executable_path_adequate_buffer(const char * expected_exe_path)
+{
+  char buffer[adequate_buffer_len];
+  bool is_trunc = false;
+  if (cwk_path_get_executable_path(buffer, adequate_buffer_len, &is_trunc) == 0) {
+    return EXIT_FAILURE;
+  }
+  if (strcmp(buffer, expected_exe_path) != 0) {
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+int executable_path_inadequate_buffer()
+{
+  char buffer[inadequate_buffer_len];
+  bool is_trunc = false;
+  if (cwk_path_get_executable_path(buffer, inadequate_buffer_len, &is_trunc) != 0 ||
+      !is_trunc) {
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+int executable_path_borderline_buffer(const char * expected_exe_path)
+{
+  // If the buffer is just long enough to fit the path, but not long enough to
+  // fit a null terminal at the end, the buffer could contain an unterminated
+  // string. This test makes sure that this will not happen.
+
+  size_t borderline_length = strlen(expected_exe_path);
+  char* buffer = (char*)malloc(borderline_length * sizeof(char));
+  bool is_trunc = false;
+
+  if (cwk_path_get_executable_path(buffer, borderline_length, &is_trunc) != 0 ||
+      buffer[0] != '\0' ||
+      !is_trunc) {
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+bool report_failure(int result, const char * test_name, const char * expected_path)
+{
+  if (EXIT_FAILURE == result) {
+    fprintf(stderr,
+            "Failed 'executable_path' test '%s' with expected_path='%s'\n",
+            test_name,
+            expected_path);
+    return true;
+  }
+  return false;
+}
+
+int main(int argc, char *argv[])
+{
+  const char * expected_path;
+  bool has_failed;
+
+  if (argc != 2) {
+    fprintf(stderr,"Usage: %s <absolute_path_to_program_executable>\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+  expected_path = argv[1];
+  has_failed = false;
+
+  has_failed |= report_failure(executable_path_adequate_buffer(expected_path),
+                               "adequate_buffer", expected_path);
+  has_failed |= report_failure(executable_path_borderline_buffer(expected_path),
+                               "borderline_buffer", expected_path);
+  has_failed |= report_failure(executable_path_inadequate_buffer(),
+                               "inadequate_buffer", expected_path);
+  return has_failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/test_executable_paths.sh
+++ b/test/test_executable_paths.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#set -eou pipefail
+
+RELATIVE_PATH_TO_EXE=$1
+EXPECTED_PATH_TO_EXE=$(realpath -s $1)
+ALIAS_TO_TEST="alias_to_cwalktest_exe_path"
+SYMLINK_TO_TEST="symlink_to_cwalktest_exe_path"
+NUM_FAILS=0
+
+alias "${ALIAS_TO_TEST}=${EXPECTED_PATH_TO_EXE}"
+shopt -s expand_aliases
+
+function record_test_result() {
+  case "$1" in
+   0) TEST_RESULT="PASSED" ;;
+   *) TEST_RESULT="FAILED" && NUM_FAILS=$((${NUM_FAILS}+1)) ;;
+  esac
+  printf "${TEST_RESULT}\n"
+}
+
+function print_running_testname() {
+  pad=$(printf '%0.1s' "."{1..30})
+  padlength=30
+  testname=$1
+  printf "Running 'executable_path/%s' %*.*s " \
+         "${testname}" 0 $((padlength - ${#testname})) "${pad}"
+}
+function simple_test() {
+  print_running_testname 'simple_test'
+  "${RELATIVE_PATH_TO_EXE}" "${EXPECTED_PATH_TO_EXE}"
+  record_test_result $?
+}
+
+function alias_test() {
+  print_running_testname 'alias_test'
+  eval "${ALIAS_TO_TEST}" "${EXPECTED_PATH_TO_EXE}"
+  record_test_result $?
+}
+
+function symlink_test() {
+  print_running_testname 'symlink_test'
+  # Make symlink
+  ln -s "${EXPECTED_PATH_TO_EXE}" "${SYMLINK_TO_TEST}"
+
+  # Test symlink
+  ./"${SYMLINK_TO_TEST}" "${EXPECTED_PATH_TO_EXE}"
+  record_test_result $?
+
+  # Remove symlink
+  rm "${SYMLINK_TO_TEST}"
+}
+
+simple_test
+alias_test
+symlink_test
+
+[[ ${NUM_FAILS} -ne 0 ]] && echo "Num failures=${NUM_FAILS}" && exit 1
+
+echo "All tests passed"
+exit 0


### PR DESCRIPTION
This is my first attempt at an implementation for Linux, Mac, Windows, FreeBSD, NetBSD, DragonFlyBSD, and Solaris. I wrote it based on the man pages and developer documentation for these platforms; links to the docs and summaries of relevant functions are included in the code. I'm opening this as a draft primarily to show what this code could look like, so you can decide it you really want something like this in cwalk or not.

The next steps would be to implement tests and get them running in CI on all platforms supported.

I think it would be worth it to add an implementation for OpenBSD. It's an odd OS to leave out, given that I have implementations for 3 other BSDs. 

Closes #20.