### PR TITLE
Made length parameter optional for cwk_path_get_basename

### DIFF
--- a/include/cwalk.h
+++ b/include/cwalk.h
@@ -159,7 +159,7 @@ CWK_PUBLIC size_t cwk_path_join_multiple(const char **paths, char *buffer,
 /**
  * @brief Determines the root of a path.
  *
- * This function determines the root of a path by finding it's length. The
+ * This function determines the root of a path by finding its length. The
  * root always starts at the submitted path. If the path has no root, the
  * length will be set to zero.
  *
@@ -222,7 +222,8 @@ CWK_PUBLIC bool cwk_path_is_relative(const char *path);
  *
  * @param path The path which will be inspected.
  * @param basename The output of the basename pointer.
- * @param length The output of the length of the basename.
+ * @param length The output of the length of the basename. This may be
+ * null if not required.
  */
 CWK_PUBLIC void cwk_path_get_basename(const char *path, const char **basename,
   size_t *length);

--- a/src/cwalk.c
+++ b/src/cwalk.c
@@ -920,7 +920,9 @@ void cwk_path_get_basename(const char *path, const char **basename,
   // to NULL and the length to 0.
   if (!cwk_path_get_last_segment(path, &segment)) {
     *basename = NULL;
-    *length = 0;
+    if (length) {
+      *length = 0;
+    }
     return;
   }
 
@@ -928,7 +930,9 @@ void cwk_path_get_basename(const char *path, const char **basename,
   // There might be trailing separators after the basename, but the size does
   // not include those.
   *basename = segment.begin;
-  *length = segment.size;
+  if (length) {
+    *length = segment.size;
+  }
 }
 
 size_t cwk_path_change_basename(const char *path, const char *new_basename,


### PR DESCRIPTION
I wanted to make use of `cwk_path_get_basename()` for a project of mine in order to strip the directory chain from a path and just keep the file name and extension. The function call works for this, but I had to provide a length variable even though I didn't need to use the length.

This PR modifies the function slightly so that `length` can safely be passed as `NULL` if the caller does not need it. I didn't think this change would be worth adding to other functions, as the purpose of the others is generally to extract a segment from the middle of the path, rather than trimming it.