### PR TITLE
chore(clib.json): make clib friendly

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,0 +1,10 @@
+{
+  "name": "cwalk",
+  "repo": "likle/cwalk",
+  "version": "v1.2.6",
+  "decription": "libcwalk - path library for C/C++",
+  "src": [
+    "src/cwalk.c",
+    "include/cwalk.h"
+  ]
+}


### PR DESCRIPTION
Hi 👋🏼 

I am one of the maintainers of https://github.com/clibs/clib.
We'd love to have support for this library in the ecosystem.
This PR adds a `clib.json` file which allows folks to do `clib install likle/cwalk`.
This will download `cwalk.h` and `cwalk.c` and place it in a `deps/cwalk/` directory 