### PR TITLE
integrates `cwalktest` with meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,7 @@ cwalk = library('cwalk', 'src/cwalk.c',
 install_headers('include/cwalk.h')
 
 cwalk_dep = declare_dependency(include_directories: 'include', link_with: cwalk)
+
+if get_option('ENABLE_TESTS')
+  subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('ENABLE_TESTS', type: 'boolean', value: false, description: 'Enables building test executables')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,23 @@
+cwalktest_sources = files(
+    'main.c',
+    'absolute_test.c',
+    'basename_test.c',
+    'dirname_test.c',
+    'extension_test.c',
+    'guess_test.c',
+    'intersection_test.c',
+    'is_absolute_test.c',
+    'is_relative_test.c',
+    'join_test.c',
+    'normalize_test.c',
+    'relative_test.c',
+    'root_test.c',
+    'segment_test.c',
+    'windows_test.c',
+)
+
+cwalktest = executable('cwalktest',
+    sources: cwalktest_sources,
+    dependencies: cwalk_dep,
+)
+test('cwalktest', cwalktest)


### PR DESCRIPTION
# Description

`cwalktest` isn't visible to meson and isn't integrated into the meson test framework

# Changes

* adds `ENABLE_TESTS` option to meson project
* adds conditional compilation of `cwalktest` executable
* registers `cwalktest` test with meson project

By default `cwalktest` won't be built, you need to enable tests via `meson configure -DENABLE_TESTS=true`.
When enabled, you can run the test via `meson test -C build`. Sample output included below:

``` console
ninja: no work to do.
ninja: Entering directory `<some_path>/cwalk/build'
ninja: no work to do.
1/1 cwalktest RUNNING       
>>> MALLOC_PERTURB_=81 <some_path>/cwalk/build/test/cwalktest
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
No unit specified. Running all tests.

 Running 'absolute/simple' .............................. SUCCESS
 Running 'absolute/absolute_path' ....................... SUCCESS
 Running 'absolute/unix_relative_base' .................. SUCCESS
 Running 'absolute/windows_relative_base' ............... SUCCESS
 Running 'absolute/mixed' ............................... SUCCESS
 Running 'absolute/normalization' ....................... SUCCESS
 Running 'absolute/too_far' ............................. SUCCESS
 Running 'absolute/check' ............................... SUCCESS
 Running 'absolute/buffer_reuse' ........................ SUCCESS
 Running 'basename/simple' .............................. SUCCESS
 Running 'basename/empty' ............................... SUCCESS
 Running 'basename/trailing_separator' .................. SUCCESS
 Running 'basename/trailing_separators' ................. SUCCESS
 Running 'basename/no_separators' ....................... SUCCESS
 Running 'basename/special_directories' ................. SUCCESS
 Running 'basename/root' ................................ SUCCESS
 Running 'basename/windows' ............................. SUCCESS
 Running 'basename/change_simple' ....................... SUCCESS
 Running 'basename/change_empty_path' ................... SUCCESS
 Running 'basename/change_only_root' .................... SUCCESS
 Running 'basename/change_empty_basename' ............... SUCCESS
 Running 'basename/change_relative' ..................... SUCCESS
 Running 'basename/change_trim' ......................... SUCCESS
 Running 'basename/change_trim_only_root' ............... SUCCESS
 Running 'dirname/simple' ............................... SUCCESS
 Running 'dirname/empty' ................................ SUCCESS
 Running 'dirname/trailing_separator' ................... SUCCESS
 Running 'dirname/trailing_separators' .................. SUCCESS
 Running 'dirname/no_separators' ........................ SUCCESS
 Running 'dirname/special_directories' .................. SUCCESS
 Running 'dirname/root' ................................. SUCCESS
 Running 'dirname/three_segments' ....................... SUCCESS
 Running 'dirname/relative' ............................. SUCCESS
 Running 'extension/get_simple' ......................... SUCCESS
 Running 'extension/get_without' ........................ SUCCESS
 Running 'extension/get_first' .......................... SUCCESS
 Running 'extension/get_last' ........................... SUCCESS
 Running 'extension/get_multiple' ....................... SUCCESS
 Running 'extension/check_simple' ....................... SUCCESS
 Running 'extension/check_empty' ........................ SUCCESS
 Running 'extension/check_without' ...................... SUCCESS
 Running 'extension/change_simple' ...................... SUCCESS
 Running 'extension/change_no_basename' ................. SUCCESS
 Running 'extension/change_no_extension' ................ SUCCESS
 Running 'extension/change_with_dot' .................... SUCCESS
 Running 'extension/change_overlap' ..................... SUCCESS
 Running 'extension/change_overlap_long' ................ SUCCESS
 Running 'extension/change_hidden_file' ................. SUCCESS
 Running 'extension/change_with_trailing_slash' ......... SUCCESS
 Running 'guess/empty_string' ........................... SUCCESS
 Running 'guess/windows_root' ........................... SUCCESS
 Running 'guess/unix_root' .............................. SUCCESS
 Running 'guess/windows_separator' ...................... SUCCESS
 Running 'guess/unix_separator' ......................... SUCCESS
 Running 'guess/hidden_file' ............................ SUCCESS
 Running 'guess/extension' .............................. SUCCESS
 Running 'guess/unguessable' ............................ SUCCESS
 Running 'intersection/simple' .......................... SUCCESS
 Running 'intersection/trailing_separator' .............. SUCCESS
 Running 'intersection/double_separator' ................ SUCCESS
 Running 'intersection/empty' ........................... SUCCESS
 Running 'intersection/unequal_roots' ................... SUCCESS
 Running 'intersection/relative_absolute_mix' ........... SUCCESS
 Running 'intersection/same_roots' ...................... SUCCESS
 Running 'intersection/one_root_only' ................... SUCCESS
 Running 'intersection/relative_base' ................... SUCCESS
 Running 'intersection/relative_other' .................. SUCCESS
 Running 'intersection/skipped_end' ..................... SUCCESS
 Running 'is_absolute/absolute' ......................... SUCCESS
 Running 'is_absolute/unc' .............................. SUCCESS
 Running 'is_absolute/device_unc' ....................... SUCCESS
 Running 'is_absolute/device_dot' ....................... SUCCESS
 Running 'is_absolute/device_question_mark' ............. SUCCESS
 Running 'is_absolute/relative' ......................... SUCCESS
 Running 'is_absolute/windows_backslash' ................ SUCCESS
 Running 'is_absolute/windows_slash' .................... SUCCESS
 Running 'is_absolute/unix_backslash' ................... SUCCESS
 Running 'is_absolute/unix_drive' ....................... SUCCESS
 Running 'is_absolute/absolute_drive' ................... SUCCESS
 Running 'is_absolute/relative_drive' ................... SUCCESS
 Running 'is_absolute/relative_windows' ................. SUCCESS
 Running 'is_absolute/root' ............................. SUCCESS
 Running 'is_absolute/dir' .............................. SUCCESS
 Running 'is_relative/absolute' ......................... SUCCESS
 Running 'is_relative/unc' .............................. SUCCESS
 Running 'is_relative/device_unc' ....................... SUCCESS
 Running 'is_relative/device_dot' ....................... SUCCESS
 Running 'is_relative/device_question_mark' ............. SUCCESS
 Running 'is_relative/relative' ......................... SUCCESS
 Running 'is_relative/windows_backslash' ................ SUCCESS
 Running 'is_relative/windows_slash' .................... SUCCESS
 Running 'is_relative/unix_backslash' ................... SUCCESS
 Running 'is_relative/unix_drive' ....................... SUCCESS
 Running 'is_relative/absolute_drive' ................... SUCCESS
 Running 'is_relative/relative_drive' ................... SUCCESS
 Running 'is_relative/relative_windows' ................. SUCCESS
 Running 'join/simple' .................................. SUCCESS
 Running 'join/navigate_back' ........................... SUCCESS
 Running 'join/empty' ................................... SUCCESS
 Running 'join/two_absolute' ............................ SUCCESS
 Running 'join/two_unc' ................................. SUCCESS
 Running 'join/with_two_roots' .......................... SUCCESS
 Running 'join/back_after_root' ......................... SUCCESS
 Running 'join/relative_back_after_root' ................ SUCCESS
 Running 'join/multiple' ................................ SUCCESS
 Running 'normalize/do_nothing' ......................... SUCCESS
 Running 'normalize/navigate_back' ...................... SUCCESS
 Running 'normalize/relative_too_far' ................... SUCCESS
 Running 'normalize/absolute_too_far' ................... SUCCESS
 Running 'normalize/terminated' ......................... SUCCESS
 Running 'normalize/double_separator' ................... SUCCESS
 Running 'normalize/remove_current' ..................... SUCCESS
 Running 'normalize/mixed' .............................. SUCCESS
 Running 'normalize/overlap' ............................ SUCCESS
 Running 'normalize/empty' .............................. SUCCESS
 Running 'normalize/only_separators' .................... SUCCESS
 Running 'normalize/back_after_root' .................... SUCCESS
 Running 'normalize/forward_slashes' .................... SUCCESS
 Running 'relative/simple' .............................. SUCCESS
 Running 'relative/relative' ............................ SUCCESS
 Running 'relative/long_base' ........................... SUCCESS
 Running 'relative/long_target' ......................... SUCCESS
 Running 'relative/equal' ............................... SUCCESS
 Running 'relative/same_base' ........................... SUCCESS
 Running 'relative/base_skipped_end' .................... SUCCESS
 Running 'relative/target_skipped_end' .................. SUCCESS
 Running 'relative/base_div_skipped_end' ................ SUCCESS
 Running 'relative/target_div_skipped_end' .............. SUCCESS
 Running 'relative/skip_all' ............................ SUCCESS
 Running 'relative/different_roots' ..................... SUCCESS
 Running 'relative/relative_and_absolute' ............... SUCCESS
 Running 'relative/check' ............................... SUCCESS
 Running 'relative/root_path_unix' ...................... SUCCESS
 Running 'relative/root_path_windows' ................... SUCCESS
 Running 'relative/root_forward_slashes' ................ SUCCESS
 Running 'root/absolute' ................................ SUCCESS
 Running 'root/unc' ..................................... SUCCESS
 Running 'root/device_unc' .............................. SUCCESS
 Running 'root/device_dot' .............................. SUCCESS
 Running 'root/device_question_mark' .................... SUCCESS
 Running 'root/relative' ................................ SUCCESS
 Running 'root/windows_backslash' ....................... SUCCESS
 Running 'root/windows_slash' ........................... SUCCESS
 Running 'root/unix_backslash' .......................... SUCCESS
 Running 'root/unix_drive' .............................. SUCCESS
 Running 'root/absolute_drive' .......................... SUCCESS
 Running 'root/relative_drive' .......................... SUCCESS
 Running 'root/relative_windows' ........................ SUCCESS
 Running 'root/change_simple' ........................... SUCCESS
 Running 'root/change_empty' ............................ SUCCESS
 Running 'root/change_separators' ....................... SUCCESS
 Running 'root/change_overlapping' ...................... SUCCESS
 Running 'root/change_without_root' ..................... SUCCESS
 Running 'segment/first' ................................ SUCCESS
 Running 'segment/last' ................................. SUCCESS
 Running 'segment/next' ................................. SUCCESS
 Running 'segment/next_too_far' ......................... SUCCESS
 Running 'segment/previous_absolute' .................... SUCCESS
 Running 'segment/previous_relative' .................... SUCCESS
 Running 'segment/previous_absolute_one_char_first' ..... SUCCESS
 Running 'segment/previous_relative_one_char_first' ..... SUCCESS
 Running 'segment/previous_too_far' ..................... SUCCESS
 Running 'segment/previous_too_far_root' ................ SUCCESS
 Running 'segment/type' ................................. SUCCESS
 Running 'segment/back_with_root' ....................... SUCCESS
 Running 'segment/change_simple' ........................ SUCCESS
 Running 'segment/change_first' ......................... SUCCESS
 Running 'segment/change_last' .......................... SUCCESS
 Running 'segment/change_trim' .......................... SUCCESS
 Running 'segment/change_empty' ......................... SUCCESS
 Running 'segment/change_with_separator' ................ SUCCESS
 Running 'segment/change_overlap' ....................... SUCCESS
 Running 'windows/change_style' ......................... SUCCESS
 Running 'windows/get_root' ............................. SUCCESS
 Running 'windows/get_unc_root' ......................... SUCCESS
 Running 'windows/get_root_separator' ................... SUCCESS
 Running 'windows/get_root_relative' .................... SUCCESS
 Running 'windows/intersection_case' .................... SUCCESS
 Running 'windows/root_backslash' ....................... SUCCESS
 Running 'windows/root_empty' ........................... SUCCESS

180/180 (100.00%) of those tests succeeded.
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
1/1 cwalktest OK              0.01s


Ok:                 1   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to <some_path>/cwalk/build/meson-logs/testlog.txt
```

#How Has This Been Tested?

Built from source using both meson, steps to repro below:

- `meson setup build`
- `meson configure -DENABLE_TESTS=true`
- `meson test -C build --verbose`
