### PR TITLE
Fix "${includedir}" does not refer to any variable

### DIFF
--- a/cwalk.pc.in
+++ b/cwalk.pc.in
@@ -3,5 +3,5 @@ Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Cflags: -I"${includedir}"
+Cflags: -I"${prefix}/include"
 Libs: -L"${prefix}/lib" -lcwalk


### PR DESCRIPTION
The cflags in pkgconfig file is invalid as "${includedir}" expands to nothing so it becomes a bare "-I"