### PR TITLE
meson: Fix symbol exporting

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,15 @@ project('cwalk', 'c',
 
 cwalk_inc = include_directories('include')
 
+cwalk_c_args = []
+if get_option('default_library') == 'shared'
+  cwalk_c_args += '-DCWK_SHARED'
+endif
+
 cwalk = library('cwalk', 'src/cwalk.c',
   install: true,
-  include_directories: cwalk_inc
+  include_directories: cwalk_inc,
+  c_args: cwalk_c_args
 )
 
 install_headers('include/cwalk.h')


### PR DESCRIPTION
When compiling in Windows with MSVC no symbols were exported. This adds the `CWK_SHARED` definition when lib is being compiled as shared.