### PR TITLE
meson: fix symbol exporting on simultaneous static and shared building

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project('cwalk', 'c',
 cwalk_inc = include_directories('include')
 
 cwalk_c_args = []
-if get_option('default_library') == 'shared'
+if get_option('default_library') != 'static'
   cwalk_c_args += '-DCWK_SHARED'
 endif
 


### PR DESCRIPTION
It turns out https://github.com/likle/cwalk/pull/46 was not the best solution.

`default_library` is a tri-state. When `both` libraries are being built, it is important to also set the exported flag.
